### PR TITLE
Support for specifying devices with serial numbers

### DIFF
--- a/Registration.cpp
+++ b/Registration.cpp
@@ -65,12 +65,12 @@ static std::vector<SoapySDR::Kwargs> findAirspyHF(const SoapySDR::Kwargs &args)
         soapyInfo["serial"] = serialstr.str();
         devId++;
                 
-        // if (args.count("serial") != 0) {
-        //     if (args.at("serial") != soapyInfo.at("serial")) {
-        //         continue;
-        //     }
-        //     SoapySDR_logf(SOAPY_SDR_DEBUG, "Found device by serial %s", soapyInfo.at("serial").c_str());
-        // } else
+        if (args.count("serial") != 0) {
+            if (args.at("serial") != soapyInfo.at("serial")) {
+                continue;
+            }
+            SoapySDR_logf(SOAPY_SDR_DEBUG, "Found device by serial %s", soapyInfo.at("serial").c_str());
+        } else
         if (args.count("device_id") != 0) {
             if (args.at("device_id") != soapyInfo.at("device_id")) {
                 continue;

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -37,6 +37,7 @@
 SoapyAirspyHF::SoapyAirspyHF(const SoapySDR::Kwargs &args)
 {
     deviceId = -1;
+    serial = 0;
 
     //sampleRate = 3000000;
     sampleRate = 768000;
@@ -58,53 +59,74 @@ SoapyAirspyHF::SoapyAirspyHF(const SoapySDR::Kwargs &args)
     sampleRateChanged.store(false);
     
     dev = nullptr;
-    
-    if (args.count("device_id") != 0)
+    bool serial_specified = false;
+    std::stringstream serialstr;
+    serialstr.str("");
+
+    if (args.count("serial") != 0)
+    {
+        try {
+            serial = std::stoull(args.at("serial"), nullptr, 16);
+        } catch (const std::invalid_argument &) {
+            throw std::runtime_error("serial is not a hex number");
+        } catch (const std::out_of_range &) {
+            throw std::runtime_error("serial value of out range");
+    }
+        serial_specified = true;
+    }
+    else if (args.count("device_id") != 0)
     {
         try {
             deviceId = std::stoi(args.at("device_id"));
         } catch (const std::invalid_argument &) {
-            throw std::runtime_error("device_id invalid.");
+            throw std::runtime_error("device_id is not a number");
+        } catch (const std::out_of_range &) {
+            throw std::runtime_error("device_id of out range");
         }
-        
-        std::vector<airspyhf_device_t *> allDevs;
-        
-        int status;
-        for (int i = 0, iMax = deviceId; i <= iMax; i++) {
-            airspyhf_device_t *searchDev = nullptr;
-            status = airspyhf_open(&searchDev);
-    
-            if (status != AIRSPYHF_SUCCESS) {
-                continue;
-            }
-    
-            allDevs.push_back(searchDev);
-        }
-
-        int numDevices = allDevs.size();
-
-        if (deviceId < 0 || deviceId >= numDevices) {
-            for (std::vector< airspyhf_device_t * >::iterator i = allDevs.begin(); i != allDevs.end(); i++) {
-                airspyhf_close(*i);
-            }
-
-            throw std::runtime_error("Airspy device_id out of range [0 .. " + std::to_string(numDevices) + "].");
-        }
-
-        dev = allDevs[deviceId];
-   
-        for (std::vector< airspyhf_device_t * >::iterator i = allDevs.begin(); i != allDevs.end(); i++) {
-            if (*i != dev) {
-                airspyhf_close(*i);
-            }
-        }
-                          
-        SoapySDR_logf(SOAPY_SDR_DEBUG, "Found AirspyHF+ device using 'device_id' = %d", deviceId);
     }
-    
-    if (deviceId == -1) {
-        throw std::runtime_error("device_id missing.");
+    uint64_t serials[MAX_DEVICES];
+    int numDevices = airspyhf_list_devices(serials, MAX_DEVICES);
+    if (numDevices == AIRSPYHF_ERROR) {
+        throw std::runtime_error("Failed to retrieve list of AirspyHF devices");
     }
+    SoapySDR_logf(SOAPY_SDR_DEBUG, "%d AirSpyHF devices found.", numDevices);
+    if (numDevices == 0) {
+        throw std::runtime_error("No AirspyHF devices found");
+    }
+
+    if (serial_specified) {     // search by serial
+        serialstr << std::hex << serial;
+        for (int i = 0; i < numDevices; i++)
+        {
+            if (serials[i] == serial)
+            {
+                deviceId = i;
+                break;
+            }
+        }
+        if (deviceId < 0)
+        {
+            throw std::runtime_error("AirspyHF device with S/N " + serialstr.str() + " not found");
+        }
+    }
+    else {                    // search by device_id
+        if (deviceId < 0)
+        {
+            deviceId = 0;       // default if no device_id specified
+        }
+        else if (deviceId >= numDevices)
+        {
+            throw std::runtime_error("Airspy device_id out of range [0 .. " + std::to_string(numDevices-1) + "].");
+        }
+        serial = serials[deviceId];
+        serialstr << std::hex << serial;
+    }
+    if (airspyhf_open_sn(&dev, serial) != AIRSPYHF_SUCCESS) {
+        throw std::runtime_error("Unable to open AirspyHF device " + std::to_string(deviceId) +
+            "with S/N " + serialstr.str());
+    }
+
+    SoapySDR_logf(SOAPY_SDR_DEBUG, "Found AirspyHF+ device: device_id = %d, serial = %16Lx", deviceId, serial);
 
 #ifdef HASGAINS
     if (airspyhf_set_hf_att(dev,rfGain)==AIRSPYHF_SUCCESS) {
@@ -150,7 +172,10 @@ SoapySDR::Kwargs SoapyAirspyHF::getHardwareInfo(void) const
 
     args["device_id"] = std::to_string(deviceId);
 
-    // maybe add Serial No. to this list?
+    std::stringstream serialstr;
+    serialstr.str("");
+    serialstr << std::hex << serial;
+    args["serial"] = serialstr.str();
 
     return args;
 }

--- a/SoapyAirspyHF.hpp
+++ b/SoapyAirspyHF.hpp
@@ -208,6 +208,7 @@ private:
 
     //device handle
     int deviceId;
+    uint64_t serial;
     airspyhf_device_t *dev;
 
     //cached settings


### PR DESCRIPTION
- Added support for "serial" parameter. Serial numbers must be specified in hex.
- If both "serial" and "device_id" are specified, "serial" takes priority.
- If neither "serial" nor "device_id" is specified, device ID of 0 is assumed.
- If "device_id" is specified, it is converted to the serial number of the requested device and then opened with `airspyhf_open_sn()`. This avoids opening all connected devices in sequence and then closing others than the one requested.

Tested with two devices.