### PR TITLE
Remove device_id parameter

### DIFF
--- a/Registration.cpp
+++ b/Registration.cpp
@@ -48,8 +48,6 @@ static std::vector<SoapySDR::Kwargs> findAirspyHF(const SoapySDR::Kwargs &args)
     	SoapySDR_logf(SOAPY_SDR_DEBUG, "%d AirSpy boards found.", count);
     }
     
-    int devId = 0;
-    
     for (int i = 0; i < count; i++) {
         std::stringstream serialstr;
         
@@ -60,27 +58,18 @@ static std::vector<SoapySDR::Kwargs> findAirspyHF(const SoapySDR::Kwargs &args)
 
         SoapySDR::Kwargs soapyInfo;
 
-        soapyInfo["device_id"] = std::to_string(devId);
         soapyInfo["label"] = "AirSpy HF+ [" + serialstr.str() + "]";
         soapyInfo["serial"] = serialstr.str();
-        devId++;
-                
+
         if (args.count("serial") != 0) {
             if (args.at("serial") != soapyInfo.at("serial")) {
                 continue;
             }
             SoapySDR_logf(SOAPY_SDR_DEBUG, "Found device by serial %s", soapyInfo.at("serial").c_str());
-        } else
-        if (args.count("device_id") != 0) {
-            if (args.at("device_id") != soapyInfo.at("device_id")) {
-                continue;
-            }
-            SoapySDR_logf(SOAPY_SDR_DEBUG, "Found device by device_id %s", soapyInfo.at("device_id").c_str());
         }
-        
+
         results.push_back(soapyInfo);
     }
-   
     return results;
 }
 

--- a/SoapyAirspyHF.hpp
+++ b/SoapyAirspyHF.hpp
@@ -207,7 +207,6 @@ public:
 private:
 
     //device handle
-    int deviceId;
     uint64_t serial;
     airspyhf_device_t *dev;
 


### PR DESCRIPTION
This removes `device_id` parameter altogether, as discussed in PR #13. The only way to select devices from now on is by using `serial` parameter.