### PR TITLE
Fix typo in cmake variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ if(CMAKE_COMPILER_IS_GNUCXX)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
     endif()
     #Thread support enabled (not the same as -lpthread)
-    list(APPEND AIRSPY_LIBS -pthread)
+    list(APPEND AIRSPYHF_LIBS -pthread)
     #disable warnings for unused parameters
     add_definitions(-Wno-unused-parameter)
 endif(CMAKE_COMPILER_IS_GNUCXX)


### PR DESCRIPTION
AIRSPY_LIBS should be AIRSPYHF_LIBS. Fixes a build issue on Fedora 32.