### PR TITLE
Don't return early from readStream() if stream not active

### DIFF
--- a/Streaming.cpp
+++ b/Streaming.cpp
@@ -225,10 +225,6 @@ int SoapyAirspyHF::readStream(
     {
         std::lock_guard <std::mutex> lock(_general_state_mutex);
 
-        if (!airspyhf_is_streaming(dev)) {
-            return 0;
-        }
-        
         if (sampleRateChanged.load()) {
             airspyhf_stop(dev);
             airspyhf_set_samplerate(dev, sampleRate);


### PR DESCRIPTION
I just got a new Airspy HF+ Discovery and was immediately hit by a problem that I have experienced before with SDRPlay  when using it over SoapyRemote. Details: https://github.com/pothosware/SoapySDRPlay/issues/68 .

This PR implements the same fix for this driver.