### PR TITLE
Update Settings.cpp

### DIFF
--- a/Settings.cpp
+++ b/Settings.cpp
@@ -289,6 +289,7 @@ SoapySDR::RangeList SoapyAirspyHF::getFrequencyRange(
     {
         results.push_back(SoapySDR::Range(9000,31000000));
 	results.push_back(SoapySDR::Range(60000000,260000000));
+	results.push_back(SoapySDR::Range(1200000000,1670000000));
     }
     return results;
 }


### PR DESCRIPTION
It is not official, but since the SDR can go there why not allow access to the range
ref: https://www.rtl-sdr.com/airspy-hf-can-receive-l-band-satcom-1-2-ghz-to-1-69-ghz/